### PR TITLE
added cisco_ios_show_ip_bgp_summary

### DIFF
--- a/group_vars/cisco_ios.yml
+++ b/group_vars/cisco_ios.yml
@@ -5,3 +5,4 @@ device_type: cisco_ios
 
 vlan_command: "show vlan"
 ip_route_command: "show ip route"
+ip_bgp_summary_command: "show ip bgp summary"

--- a/hosts
+++ b/hosts
@@ -6,6 +6,10 @@ password=!cisco123!
 username=cisco
 password=!cisco123!
 
+[cisoc_ios:vars]
+username=cisco
+password=!cisco123!
+
 [hp_comware:vars]
 username=hp
 password=hp123
@@ -15,3 +19,6 @@ n9k1
 
 [hp_comware]
 hp1
+
+[cisco_ios]
+router1

--- a/ntc_templates/cisco_ios_show_ip_bgp_summary.template
+++ b/ntc_templates/cisco_ios_show_ip_bgp_summary.template
@@ -1,0 +1,6 @@
+Value BGP_NEIGH (\d+\.\d+\.\d+\.\d+)
+Value NEIGH_AS (\d+)
+Value STATE_PFXRCD (\S+.*)
+
+Start
+  ^${BGP_NEIGH}\s+\S+\s+${NEIGH_AS}(\s+\S+){6}\s+${STATE_PFXRCD}\s -> Record

--- a/ntc_templates/index
+++ b/ntc_templates/index
@@ -11,3 +11,4 @@ hp_comware_display_vlan_brief.template, .*, hp_comware, di[[splay]] v[[lan]] b[[
 cisco_nxos_show_version.template, .*, cisco_nxos, sh[[ow]] ver[[sion]]
 cisco_wlc_ssh_show_sysinfo.template, .*, cisco_wlc_ssh, sh[[ow]] sysi[[nfo]]
 cisco_ios_show_spanning-tree.template, .*, cisco_ios, sh[[ow]] sp[[anning-tree]]
+cisco_ios_show_ip_bgp_summary.template, .*, cisco_ios, sh[[ow]] ip bgp sum[[mary]]

--- a/tests/cisco_ios/cisco_ios_show_ip_bgp_summary.parsed
+++ b/tests/cisco_ios/cisco_ios_show_ip_bgp_summary.parsed
@@ -1,0 +1,42 @@
+---
+parsed_sample:
+
+- bgp_neigh: '10.0.0.1'
+  neigh_as: '65000'
+  state_pfxrcd: '558720'
+
+- bgp_neigh: '10.0.0.2'
+  neigh_as: '65001'
+  state_pfxrcd: '558720'
+
+- bgp_neigh: '10.0.0.3'
+  neigh_as: '65002'
+  state_pfxrcd: '0'
+
+- bgp_neigh: '10.0.0.4'
+  neigh_as: '65003'
+  state_pfxrcd: '1351'
+
+- bgp_neigh: '10.0.0.5'
+  neigh_as: '65004'
+  state_pfxrcd: '558720'
+
+- bgp_neigh: '10.0.0.6'
+  neigh_as: '65005'
+  state_pfxrcd: '558720'
+
+- bgp_neigh: '10.0.0.7'
+  neigh_as: '65006'
+  state_pfxrcd: '82'
+
+- bgp_neigh: '10.0.0.8'
+  neigh_as: '65007'
+  state_pfxrcd: '82'
+
+- bgp_neigh: '10.0.0.9'
+  neigh_as: '65008'
+  state_pfxrcd: '0'
+
+- bgp_neigh: '10.0.0.10'
+  neigh_as: '65009'
+  state_pfxrcd: 'Idle (Admin)'

--- a/tests/cisco_ios/cisco_ios_show_ip_bgp_summary.raw
+++ b/tests/cisco_ios/cisco_ios_show_ip_bgp_summary.raw
@@ -1,0 +1,26 @@
+BGP router identifier 10.0.0.0, local AS number 65000
+BGP table version is 512185206, main routing table version 512185206
+566019 network entries using 140372712 bytes of memory
+4478571 path entries using 501599952 bytes of memory
+448860/89167 BGP path/bestpath attribute entries using 100544640 bytes of memory
+78 BGP rrinfo entries using 3120 bytes of memory
+208442 BGP AS-PATH entries using 10129234 bytes of memory
+1790 BGP community entries using 180118 bytes of memory
+30 BGP extended community entries using 976 bytes of memory
+1015 BGP route-map cache entries using 64960 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 752895712 total bytes of memory
+1121781 received paths for inbound soft reconfiguration
+BGP activity 19247146/18656050 prefixes, 368760729/364163114 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.0.0.1        4        65000 2746767 2396274 512185206    0    0 3w0d       558720
+10.0.0.2        4        65001 2855873 2409742 512185206    0    0 3w0d       558720
+10.0.0.3        4        65002  695143  689871 512185203    0    0 1y10w           0
+10.0.0.4        4        65003 1030294 1220041 512185206    0    0 1y50w        1351
+10.0.0.5        4        65004 26552304 14931352 512185206    0    0 19w5d      558720
+10.0.0.6        4        65005 26532908 14931123 512185206    0    0 19w5d      558720
+10.0.0.7        4        65006 12245684 9181569 512185203    0    0 1y10w          82
+10.0.0.8        4        65007 12250936 9181571 512185203    0    0 1y10w          82
+10.0.0.9        4        65008  222146 14368489 512185203    0    0 22w0d           0
+10.0.0.10       4        65009 26930508  942614 512185203    0    0 1y10w     Idle (Admin) 


### PR DESCRIPTION
Added functionality for parsing IPv4 BGP Neighbors on Cisco IOS.