### PR TITLE
fix test-template.yml playbook after tests directory restructure

### DIFF
--- a/test-template.yml
+++ b/test-template.yml
@@ -30,7 +30,7 @@
       platform: "{{ platform }}"
       command: "{{ command }}"
     with_fileglob:
-      - "{{ TEST_DIR }}/{{ platform }}/{{ template_name}}*.raw"
+      - "{{ TEST_DIR }}/{{ platform }}/{{ command_variable}}/{{ template_name}}*.raw"
     register: ntc_result
 
   - name: read parsed sample files


### PR DESCRIPTION
Restructuring the tests directory broke the test-template.yml playbook. I've implemented a fix.