### PR TITLE
Simplify clitable_to_dict function / Add support for non-standard SSH port

### DIFF
--- a/library/ntc_show_command
+++ b/library/ntc_show_command
@@ -134,25 +134,12 @@ import clitable
 def clitable_to_dict(cli_table):
     """Converts TextFSM cli_table object to list of dictionaries
     """
-
-    # number of rows within the table excluding the headers
-    object_rows = cli_table.size
-
-    rows = []
-
-    # build list of row objects - each row is list-like
-    for each in range(0, object_rows):
-        cli_table.row_index = each + 1
-        rows.append(cli_table.row)
-
     objs = []
-    for row in rows:
-        temp = {}
-        index = 0
-        for each in row:
-            temp[cli_table.header[index].lower()] = each
-            index += 1
-        objs.append(temp)
+    for row in cli_table:
+        temp_dict = {}
+        for index, element in enumerate(row):
+            temp_dict[cli_table.header[index].lower()] = element
+        objs.append(temp_dict)
 
     return objs
 

--- a/library/ntc_show_command
+++ b/library/ntc_show_command
@@ -84,6 +84,13 @@ options:
         default: null
         choices: []
         aliases: []
+    port:
+        description:
+            - SSH port to use to connect to the target device
+        required: false
+        default: 22
+        choices: []
+        aliases: []
     username:
         description:
             - Username used to login to the target device
@@ -162,6 +169,7 @@ def main():
             template_dir=dict(default='ntc_templates'),
             command=dict(required=True),
             host=dict(required=False),
+            port=dict(default=22, required=False),
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str'),
         ),
@@ -180,6 +188,7 @@ def main():
     command = module.params['command']
     username = module.params['username']
     password = module.params['password']
+    port = int(module.params['port'])
 
     if module.params['host']:
         host = socket.gethostbyname(module.params['host'])
@@ -204,6 +213,7 @@ def main():
         device = ConnectHandler(
                     device_type=device_type,
                     ip=socket.gethostbyname(host),
+                    port=port,
                     username=username,
                     password=password
                     )


### PR DESCRIPTION
I added a port argument to ntc_show_command that gets passed to Netmiko during connection. Will default to 22 if not specified. Not required to be present in playbook.

I tested it out in my environment against Cisco IOS and worked properly (both 'port' being specified in playbook and not being specified in playbook).

I didn't update other auxiliary files like examples.md (probably not a common enough use case to be needed in examples).