### PR TITLE
Modify test-template.yml to not find parsed files based on splitting on a "."

### DIFF
--- a/test-template.yml
+++ b/test-template.yml
@@ -34,7 +34,7 @@
     register: ntc_result
 
   - name: read parsed sample files
-    include_vars: "{{ item.item | split('.') | first }}.parsed"
+    include_vars: "{{ item.item | regex_replace('\\.raw$', '.parsed') }}"
     with_items: "{{ ntc_result.results }}"
     register: ntc_result
 


### PR DESCRIPTION
I was trying to figure out why the test-template.yml wasn't working for me on a different computer until I twigged that it was the extra dot in the path. I've modified the expression to just replace .raw with .parsed as I believe this is the objective.

Sorry I've been sitting on this a little while but I was concerned if I added another branch I'd completely lose track with all the rebases!

Thanks!