### PR TITLE
Fix ios sh ip route

### DIFF
--- a/ntc_templates/cisco_ios_show_ip_route.template
+++ b/ntc_templates/cisco_ios_show_ip_route.template
@@ -1,4 +1,4 @@
-Value Filldown Protocol (C|S|R|B|D|O|i)
+Value Filldown Protocol (C|S|R|B|D|O|i|L)
 Value Filldown Type (\w{0,2})
 Value Required,Filldown Network ([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})
 Value Filldown Mask (\/\d{1,2})

--- a/ntc_templates/cisco_ios_show_ip_route.template
+++ b/ntc_templates/cisco_ios_show_ip_route.template
@@ -29,3 +29,5 @@ Routes
   #
   # Clear all variables on empty lines
   ^\s* -> Clearall
+
+EOF

--- a/tests/cisco_ios/show_ip_route/cisco_ios_show_ip_route.parsed
+++ b/tests/cisco_ios/show_ip_route/cisco_ios_show_ip_route.parsed
@@ -1,202 +1,202 @@
 ---
 parsed_sample:
-      
+
 - network: 1.1.1.1
-  distance: 1
+  distance: '1'
   mask: /32
-  metric: 0
-  nexthopif: 
+  metric: '0'
+  nexthopif: ''
   nexthopip: 212.0.0.1
   protocol: S
-  type: 
-  uptime: 
-            
+  type: ''
+  uptime: ''
+
 - network: 1.1.1.1
-  distance: 1
+  distance: '1'
   mask: /32
-  metric: 0
-  nexthopif: 
+  metric: '0'
+  nexthopif: ''
   nexthopip: 192.168.0.1
   protocol: S
-  type: 
-  uptime: 
-            
+  type: ''
+  uptime: ''
+
 - network: 2.2.2.0
-  distance: 
+  distance: ''
   mask: /24
-  metric: 
+  metric: ''
   nexthopif: FastEthernet0/0
-  nexthopip: 
+  nexthopip: ''
   protocol: S
-  type: 
-  uptime: 
-            
+  type: ''
+  uptime: ''
+
 - network: 4.4.0.0
-  distance: 110
+  distance: '110'
   mask: /16
-  metric: 20
+  metric: '20'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
-  protocol: O
+  protocol: 'O'
   type: E2
   uptime: 00:02:00
-            
+
 - network: 5.5.5.0
-  distance: 170
+  distance: '170'
   mask: /24
-  metric: 2297856
+  metric: '2297856'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: D
   type: EX
   uptime: 00:12:01
-            
+
 - network: 6.6.0.0
-  distance: 200
+  distance: '200'
   mask: /16
-  metric: 0
-  nexthopif: 
+  metric: '0'
+  nexthopif: ''
   nexthopip: 195.0.0.1
   protocol: B
-  type: 
+  type: ''
   uptime: 00:00:04
-            
+
 - network: 172.16.1.0
-  distance: 115
+  distance: '115'
   mask: /26
-  metric: 10
+  metric: '10'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: i
   type: L2
-  uptime: 
-            
+  uptime: ''
+
 - network: 172.20.1.1
-  distance: 110
+  distance: '110'
   mask: /32
-  metric: 11
+  metric: '11'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
   protocol: O
-  type: 
+  type: ''
   uptime: 00:05:45
-            
+
 - network: 172.20.3.1
-  distance: 110
+  distance: '110'
   mask: /32
-  metric: 11
+  metric: '11'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
   protocol: O
-  type: 
+  type: ''
   uptime: 00:05:45
-            
+
 - network: 172.20.2.1
-  distance: 110
+  distance: '110'
   mask: /32
-  metric: 11
+  metric: '11'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
   protocol: O
-  type: 
+  type: ''
   uptime: 00:05:45
-            
+
 - network: 10.0.1.0
-  distance: 
+  distance: ''
   mask: /24
-  metric: 
+  metric: ''
   nexthopif: Serial0/0
-  nexthopip: 
+  nexthopip: ''
   protocol: C
-  type: 
-  uptime: 
-            
+  type: ''
+  uptime: ''
+
 - network: 10.0.5.0
-  distance: 90
+  distance: '90'
   mask: /26
-  metric: 2297856
+  metric: '2297856'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: D
-  type: 
+  type: ''
   uptime: 00:12:03
-            
+
 - network: 10.0.5.64
-  distance: 90
+  distance: '90'
   mask: /26
-  metric: 2297856
+  metric: '2297856'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: D
-  type: 
+  type: ''
   uptime: 00:12:03
-            
+
 - network: 10.0.5.128
-  distance: 90
+  distance: '90'
   mask: /26
-  metric: 2297856
+  metric: '2297856'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: D
-  type: 
+  type: ''
   uptime: 00:12:03
-            
+
 - network: 10.0.5.192
-  distance: 90
+  distance: '90'
   mask: /27
-  metric: 2297856
+  metric: '2297856'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: D
-  type: 
+  type: ''
   uptime: 00:12:03
-            
+
 - network: 192.168.0.1
-  distance: 90
+  distance: '90'
   mask: /32
-  metric: 2297856
+  metric: '2297856'
   nexthopif: Serial0/0
   nexthopip: 10.0.1.2
   protocol: D
-  type: 
+  type: ''
   uptime: 00:12:03
-            
+
 - network: 195.0.0.0
-  distance: 110
+  distance: '110'
   mask: /24
-  metric: 11
+  metric: '11'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
   protocol: O
   type: IA
   uptime: 00:05:45
-            
+
 - network: 0.0.0.0
-  distance: 110
+  distance: '110'
   mask: /0
-  metric: 1
+  metric: '1'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
   protocol: O
   type: E2
   uptime: 00:05:35
-            
+
 - network: 212.0.0.0
-  distance: 110
+  distance: '110'
   mask: /8
-  metric: 20
+  metric: '20'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
   protocol: O
   type: E2
   uptime: 00:05:35
-            
+
 - network: 194.0.0.0
-  distance: 
+  distance: ''
   mask: /16
-  metric: 
+  metric: ''
   nexthopif: FastEthernet0/0
-  nexthopip: 
+  nexthopip: ''
   protocol: C
-  type: 
-  uptime: 
+  type: ''
+  uptime: ''


### PR DESCRIPTION
This PR resolves #31, including:

- adding "EOF" to the cisco_ios_show_ip_route.template
- adding quotes to integers and and empty strings in cisco_ios_show_ip_route.parsed
- adding the L type of route to the template