### PR TITLE
Cisco ios show interfaces status

### DIFF
--- a/hosts
+++ b/hosts
@@ -22,3 +22,6 @@ hp1
 
 [cisco_ios]
 router1
+
+[arista_eos]
+arista1

--- a/ntc_templates/arista_eos_show_vlan.template
+++ b/ntc_templates/arista_eos_show_vlan.template
@@ -1,0 +1,6 @@
+Value VLAN_ID (\d+)
+Value NAME (\w+)
+Value STATUS (active|suspended)
+
+Start
+  ^${VLAN_ID}\s+${NAME}\s+${STATUS} -> Record

--- a/ntc_templates/cisco_ios_show_interfaces_status.template
+++ b/ntc_templates/cisco_ios_show_interfaces_status.template
@@ -1,0 +1,12 @@
+Value PORT (([a-zA-Z])\w+/\d+|mgmt\d+|Po\d+|Lo\d+|Vlan\d+)
+Value NAME (\S+(\s\w+\s\w+)?)
+Value STATUS (\w+)
+Value VLAN (\w+)
+Value DUPLEX (a-full|auto|half)
+Value SPEED (auto|\w+-\d+|\d+)
+Value TYPE (.*)
+
+Start
+  ^${PORT}\s+${NAME}\s+${STATUS}\s+${VLAN}\s+${DUPLEX}\s+${SPEED}\s+${TYPE} -> Record
+  ^${PORT}\s+${STATUS}\s+${VLAN}\s+${DUPLEX}\s+${SPEED}\s+${TYPE} -> Record
+

--- a/ntc_templates/index
+++ b/ntc_templates/index
@@ -22,3 +22,4 @@ cisco_nxos_show_flogi_database.template, .*, cisco_nxos, sh[[ow]] fl[[ogi]] d[[a
 cisco_ios_show_interfaces.template, .*, cisco_ios, sh[[ow]] int[[erfaces]]
 cisco_ios_show_clock.template, .*, cisco_ios, sh[[ow]] c[[lock]]
 cisco_nxos_show_clock.template, .*, cisco_nxos, sh[[ow]] c[[lock]]
+arista_eos_show_vlan.template, .*, arista_eos, sh[[ow]] vl[[an]]

--- a/ntc_templates/index
+++ b/ntc_templates/index
@@ -22,4 +22,4 @@ cisco_nxos_show_flogi_database.template, .*, cisco_nxos, sh[[ow]] fl[[ogi]] d[[a
 cisco_ios_show_interfaces.template, .*, cisco_ios, sh[[ow]] int[[erfaces]]
 cisco_ios_show_clock.template, .*, cisco_ios, sh[[ow]] c[[lock]]
 cisco_nxos_show_clock.template, .*, cisco_nxos, sh[[ow]] c[[lock]]
-arista_eos_show_vlan.template, .*, arista_eos, sh[[ow]] vl[[an]]
+cisco_ios_show_interfaces_status, .*, cisco_ios, sh[[ow]] int[[erfaces]] s[[tatus]]

--- a/tests/arista_eos/show_vlan/arista_eos_show_vlan.parsed
+++ b/tests/arista_eos/show_vlan/arista_eos_show_vlan.parsed
@@ -1,0 +1,19 @@
+---
+parsed_sample:
+- name: default
+  status: active
+  vlan_id: "1"
+
+- name: Test1
+  status: active
+  vlan_id: "10"
+
+- name: Test2
+  status: suspended
+  vlan_id: "20"
+
+- name: VLAN0030
+  status: suspended
+  vlan_id: "30"
+
+

--- a/tests/arista_eos/show_vlan/arista_eos_show_vlan.raw
+++ b/tests/arista_eos/show_vlan/arista_eos_show_vlan.raw
@@ -1,0 +1,6 @@
+VLAN  Name                             Status    Ports
+----- -------------------------------- --------- -------------------------------
+1     default                          active    Et1
+10    Test1                            active    Et1, Et2
+20    Test2                            suspended
+30    VLAN0030                         suspended


### PR DESCRIPTION
I'm experiencing a strange issue: when I test the TextFSM template alone, everything works. Instead, if I test it with ntc-ansible, it doesn't work and, even stranger, it doesn't return no errors.