### PR TITLE
Introducing ntc_write_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ hp-comware_5900
 ## ntc_write_command
 Writes config data to devices that don't have an API
 
-  *[Synopsis](#ntc_write_synopsis)
-  *[Options](#ntc_write_options)
-  *[Examples](#ntc_write_examples)
+  * [Synopsis](#ntc_write_synopsis)
+  * [Options](#ntc_write_options)
+  * [Examples](#ntc_write_examples)
 
 ### ntc_write_synopsis
 This module writes configuration data to non-API enabled devices, via CLI, using netmiko for SSH connectivity.

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Writes config data to devices that don't have an API
   *[Options](#ntc_write_options)
   *[Examples](#ntc_write_examples)
 
-### ntc_write synopsis
+### ntc_write_synopsis
 This module writes configuration data to non-API enabled devices, via CLI, using netmiko for SSH connectivity.
 
-### ntc_write options
+### ntc_write_options
 
 | Parameter     | Required | Default | Choices | Comments                                                                                                                                           |
 |---------------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -102,7 +102,7 @@ This module writes configuration data to non-API enabled devices, via CLI, using
 | commands      | no       |         |         | Commands should be in a list format. config t isn't needed, as netmiko will automatically enter config mode to execute commands                    |
 | commands_file | no       |         |         | the commands_file option can be very useful if you generate commands based upon the results of a ntc_show_command play.                            |
 
-### ntc_write examples
+### ntc_write_examples
 
 Example using the commands option
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### Modules
 
   * [ntc_show_command - gets config data from devices that don't have an api](#ntc_show_command)
-  * [ntc_write_command - writes config data to devices that don't have an api](#ntc_write_command)
+  * [ntc_config_command - writes config data to devices that don't have an api](#ntc_config_command)
 
 ---
 
@@ -78,23 +78,23 @@ hp-comware_5900
 
 ```
 
-## ntc_write_command
+## ntc_config_command
 Writes config data to devices that don't have an API
 
-  * [Synopsis](#ntc_write_synopsis)
-  * [Options](#ntc_write_options)
-  * [Examples](#ntc_write_examples)
+  * [Synopsis](#ntc_config_synopsis)
+  * [Options](#ntc_config_options)
+  * [Examples](#ntc_config_examples)
 
-### ntc_write_synopsis
+### ntc_config_synopsis
 This module writes configuration data to non-API enabled devices, via CLI, using netmiko for SSH connectivity.
 
-### ntc_write_options
+### ntc_config_options
 
 | Parameter     | Required | Default | Choices | Comments                                                                                                                                           |
 |---------------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | username      | no       |         |         | Username used to login to the target device                                                                                                        |
 | password      | no       |         |         | Password used to login to the target device                                                                                                        |
-| secret        | no       |         |         | Specify the administrative password to allow ntc_write_command to make changes. On cisco devices, this is the equivalent to the enable password.   |
+| secret        | no       |         |         | Specify the administrative password to allow ntc_config_command to make changes. On cisco devices, this is the equivalent to the enable password.   |
 | connection    | no       | ssh     | ssh     | Connect to device using netmiko                                                                                                                    |
 | port          | no       | 22      |         | Specify the port for netmiko to SSH to. The default is 22.                                                                                         |
 | platform      | yes      |         |         | Required by netmiko in order to use the proper connection module for the type of device. It follows the same naming scheme as the ntc_show_command |
@@ -102,12 +102,12 @@ This module writes configuration data to non-API enabled devices, via CLI, using
 | commands      | no       |         |         | Commands should be in a list format. config t isn't needed, as netmiko will automatically enter config mode to execute commands                    |
 | commands_file | no       |         |         | the commands_file option can be very useful if you generate commands based upon the results of a ntc_show_command play.                            |
 
-### ntc_write_examples
+### ntc_config_examples
 
 Example using the commands option
 ```
 # write vlan data
-- ntc_write_command:
+- ntc_config_command:
     connection: ssh
     platform: cisco_ios
     commands:
@@ -122,7 +122,7 @@ Example using the commands option
 Example using the commands_file option
 ```
 # write config from file
-- ntc_write_command:
+- ntc_config_command:
     connection: ssh
     platform: cisco_ios
     commands_file: "dynamically_created_config.txt"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ### Modules
 
   * [ntc_show_command - gets config data from devices that don't have an api](#ntc_show_command)
+  * [ntc_write_command - writes config data to devices that don't have an api](#ntc_write_command)
 
 ---
 
@@ -77,6 +78,59 @@ hp-comware_5900
 
 ```
 
+## ntc_write_command
+Writes config data to devices that don't have an API
+
+  *[Synopsis](#ntc_write_synopsis)
+  *[Options](#ntc_write_options)
+  *[Examples](#ntc_write_examples)
+
+### ntc_write synopsis
+This module writes configuration data to non-API enabled devices, via CLI, using netmiko for SSH connectivity.
+
+### ntc_write options
+
+| Parameter     | Required | Default | Choices | Comments                                                                                                                                           |
+|---------------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| username      | no       |         |         | Username used to login to the target device                                                                                                        |
+| password      | no       |         |         | Password used to login to the target device                                                                                                        |
+| secret        | no       |         |         | Specify the administrative password to allow ntc_write_command to make changes. On cisco devices, this is the equivalent to the enable password.   |
+| connection    | no       | ssh     | ssh     | Connect to device using netmiko                                                                                                                    |
+| port          | no       | 22      |         | Specify the port for netmiko to SSH to. The default is 22.                                                                                         |
+| platform      | yes      |         |         | Required by netmiko in order to use the proper connection module for the type of device. It follows the same naming scheme as the ntc_show_command |
+| host          | yes      |         |         | IP Address or hostname (resolvable by Ansible control host)                                                                                        |
+| commands      | no       |         |         | Commands should be in a list format. config t isn't needed, as netmiko will automatically enter config mode to execute commands                    |
+| commands_file | no       |         |         | the commands_file option can be very useful if you generate commands based upon the results of a ntc_show_command play.                            |
+
+### ntc_write examples
+
+Example using the commands option
+```
+# write vlan data
+- ntc_write_command:
+    connection: ssh
+    platform: cisco_ios
+    commands:
+      - vlan 10
+      - name vlan_10
+      - end
+    host: "{{ inventory_hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    secret: "{{ secret }}"
+```
+Example using the commands_file option
+```
+# write config from file
+- ntc_write_command:
+    connection: ssh
+    platform: cisco_ios
+    commands_file: "dynamically_created_config.txt"
+    host: "{{ inventory_hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    secret: "{{ secret }}"
+```
 ---
 
 

--- a/hosts
+++ b/hosts
@@ -2,13 +2,10 @@
 username=cisco
 password=!cisco123!
 
-[cisco_nxos:vars]
-username=cisco
-password=!cisco123!
-
 [cisoc_ios:vars]
 username=cisco
 password=!cisco123!
+secret=!supersecret!
 
 [hp_comware:vars]
 username=hp

--- a/library/ntc_config_command
+++ b/library/ntc_config_command
@@ -16,7 +16,7 @@
 
 DOCUMENTATION = '''
 ---
-module: ntc_write_command
+module: ntc_config_command
 short_description: Writes config data to devices that don't have an API
 description:
     - This module write config data to devices that don't have an API.
@@ -84,7 +84,7 @@ options:
         aliases: []
     secret:
         description:
-            - Password used to login to the target device
+            - Password used to enter a privileged mode on the target device
         required: false
         default: null
         choices: []
@@ -93,7 +93,7 @@ options:
 EXAMPLES = '''
 
 # write vlan data
-- ntc_write_command:
+- ntc_config_command:
     connection: ssh
     platform: cisco_nxos
     commands:
@@ -106,7 +106,7 @@ EXAMPLES = '''
     secret: "{{ secret }}"
 
 # write config from file
-- ntc_write_command:
+- ntc_config_command:
     connection: ssh
     platform: cisco_nxos
     commands_file: "dynamically_created_config.txt"

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -187,7 +187,7 @@ def main():
             module.fail_json(msg="Unable to locate: {}".format(commands_file))
 
     results = {}
-    results['response'] = output 
+    results['response'] = output
 
     module.exit_json(changed=True, **results)
 

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -123,7 +123,7 @@ EXAMPLES = '''
 '''
 
 module = AnsibleModule(
-     argument_spec=dict(
+    argument_spec=dict(
         connection=dict(choices=['ssh'],
                         default='ssh'),
         platform=dict(required=True),
@@ -193,7 +193,7 @@ def main(module):
         except:
             module.fail_json(msg="Unable to locate: {}".format(commands_file))
 
-    if (error_params(platform,output)):
+    if (error_params(platform, output)):
         module.fail_json(msg="Error executing command:\
                          {}".format(output))
 

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+
+import os.path
+import socket
+from ansible.module_utils.basic import *
+from netmiko import ConnectHandler
+
+
+# Copyright 2015 James Williams <james.williams@packetgeek.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = '''
+---
+module: ntc_write_command
+short_description: Writes config data to devices that don't have an API
+description:
+    - This module write config data to devices that don't have an API.
+      The use case would be writing configuration based on output gleaned
+      from ntc_show_command output.
+author: James Williams (@packetgeeknet)
+requirements:
+    - netmiko
+options:
+    connection:
+        description:
+            - connect to device using netmiko or read from offline file
+              for testing
+        required: false
+        default: ssh
+        choices: ['ssh']
+        aliases: []
+    platform:
+        description:
+            - Platform FROM the index file
+        required: true
+        default: ssh
+        choices: []
+        aliases: []
+    commands:
+        description:
+            - Command to execute on target device
+        required: false
+        default: null
+        choices: []
+        aliases: []
+    commands_file:
+        description:
+            - Command to execute on target device
+        required: true
+        default: null
+        choices: []
+    host:
+        description:
+            - IP Address or hostname (resolvable by Ansible control host)
+        required: false
+        default: null
+        choices: []
+        aliases: []
+    port:
+        description:
+            - SSH port to use to connect to the target device
+        required: false
+        default: 22
+        choices: []
+        aliases: []
+    username:
+        description:
+            - Username used to login to the target device
+        required: false
+        default: null
+        choices: []
+        aliases: []
+    password:
+        description:
+            - Password used to login to the target device
+        required: false
+        default: null
+        choices: []
+        aliases: []
+    enable_password:
+        description:
+            - Password used to login to the target device
+        required: false
+        default: null
+        choices: []
+        aliases: []
+'''
+EXAMPLES = '''
+
+# write vlan data
+- ntc_write_command:
+    connection: ssh
+    platform: cisco_nxos
+    commands:
+      - vlan 10
+      - name vlan_10
+      - end
+    host: "{{ inventory_hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    enable_password: "{{ enable_password }}"
+
+# write config from file
+- ntc_write_command:
+    connection: ssh
+    platform: cisco_nxos
+    commands_file: "dynamically_created_config.txt"
+    host: "{{ inventory_hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    enable_password: "{{ enable_password }}"
+'''
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            connection=dict(choices=['ssh'],
+                            default='ssh'),
+            platform=dict(required=True),
+            commands=dict(required=False),
+            commands_file=dict(required=False),
+            host=dict(required=False),
+            port=dict(default=22, required=False),
+            username=dict(required=False, type='str'),
+            password=dict(required=False, type='str'),
+            enable_password=dict(required=False, type='str'),
+        ),
+        required_together=(
+            ['host', 'password', 'username'],
+        ),
+        supports_check_mode=False
+    )
+
+    connection = module.params['connection']
+    platform = module.params['platform']
+    device_type = platform.split('-')[0]
+    commands = module.params['commands']
+    commands_file = module.params['commands_file']
+    username = module.params['username']
+    password = module.params['password']
+    enable_password = module.params['enable_password']
+    port = int(module.params['port'])
+
+    if module.params['host']:
+        host = socket.gethostbyname(module.params['host'])
+
+    if connection == 'ssh' and not module.params['host']:
+        module.fail_json(msg='specify host if using connection=ssh')
+
+    if connection == 'ssh':
+
+        device = ConnectHandler(device_type=device_type,
+                                ip=socket.gethostbyname(host),
+                                port=port,
+                                username=username,
+                                password=password
+                                secret=enable_password)
+
+        if secret:
+            device.enable()
+
+        if commands:
+            output = device.send_config_set(commands)
+
+        try:
+            if commands_file:
+                if os.path.isfile(commands_file):
+                    with open(commands_file, 'r') as f:
+                        output = device.send_config_set(f.readlines())
+        except:
+            module.fail_json(msg="Unable to locate: {}".format(commands_file))
+
+    results = {}
+    results['response'] = structured_data
+
+    module.exit_json(**results)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
 
-import os.path
-import socket
-from ansible.module_utils.basic import *
-from netmiko import ConnectHandler
-
-
 # Copyright 2015 James Williams <james.williams@packetgeek.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,24 +116,9 @@ EXAMPLES = '''
     secret: "{{ secret }}"
 '''
 
-module = AnsibleModule(
-    argument_spec=dict(
-        connection=dict(choices=['ssh'],
-                        default='ssh'),
-        platform=dict(required=True),
-        commands=dict(required=False),
-        commands_file=dict(required=False),
-        host=dict(required=False),
-        port=dict(default=22, required=False),
-        username=dict(required=False, type='str'),
-        password=dict(required=False, type='str'),
-        secret=dict(required=False, type='str'),
-    ),
-    required_together=(
-        ['host', 'password', 'username'],
-    ),
-    supports_check_mode=False
-)
+import os.path
+import socket
+from netmiko import ConnectHandler
 
 
 def error_params(platform, command_output):
@@ -152,7 +131,26 @@ def error_params(platform, command_output):
             return False
 
 
-def main(module):
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            connection=dict(choices=['ssh'],
+                            default='ssh'),
+            platform=dict(required=True),
+            commands=dict(required=False),
+            commands_file=dict(required=False),
+            host=dict(required=False),
+            port=dict(default=22, required=False),
+            username=dict(required=False, type='str'),
+            password=dict(required=False, type='str'),
+            secret=dict(required=False, type='str'),
+        ),
+        required_together=(
+            ['host', 'password', 'username'],
+        ),
+        supports_check_mode=False
+    )
 
     connection = module.params['connection']
     platform = module.params['platform']
@@ -203,5 +201,6 @@ def main(module):
     module.exit_json(changed=True, **results)
 
 
+from ansible.module_utils.basic import *
 if __name__ == "__main__":
-    main(module)
+    main()

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -174,6 +174,9 @@ def main():
 
         if commands:
             output = device.send_config_set(commands)
+            if "'^' marker" in output:
+                module.fail_json(msg="Error executing command:\
+                                 {}".format(output))
 
         try:
             if commands_file:
@@ -186,7 +189,7 @@ def main():
     results = {}
     results['response'] = output 
 
-    module.exit_json(**results)
+    module.exit_json(changed=True, **results)
 
 
 if __name__ == "__main__":

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -122,27 +122,37 @@ EXAMPLES = '''
     secret: "{{ secret }}"
 '''
 
+module = AnsibleModule(
+     argument_spec=dict(
+        connection=dict(choices=['ssh'],
+                        default='ssh'),
+        platform=dict(required=True),
+        commands=dict(required=False),
+        commands_file=dict(required=False),
+        host=dict(required=False),
+        port=dict(default=22, required=False),
+        username=dict(required=False, type='str'),
+        password=dict(required=False, type='str'),
+        secret=dict(required=False, type='str'),
+    ),
+    required_together=(
+        ['host', 'password', 'username'],
+    ),
+    supports_check_mode=False
+)
 
-def main():
 
-    module = AnsibleModule(
-        argument_spec=dict(
-            connection=dict(choices=['ssh'],
-                            default='ssh'),
-            platform=dict(required=True),
-            commands=dict(required=False),
-            commands_file=dict(required=False),
-            host=dict(required=False),
-            port=dict(default=22, required=False),
-            username=dict(required=False, type='str'),
-            password=dict(required=False, type='str'),
-            secret=dict(required=False, type='str'),
-        ),
-        required_together=(
-            ['host', 'password', 'username'],
-        ),
-        supports_check_mode=False
-    )
+def error_params(platform, command_output):
+    if 'cisco_ios' in platform:
+        if "Invalid input detected at '^' marker" in command_output:
+            return True
+        elif "Ambiguous command" in command_output:
+            return True
+        else:
+            return False
+
+
+def main(module):
 
     connection = module.params['connection']
     platform = module.params['platform']
@@ -174,9 +184,6 @@ def main():
 
         if commands:
             output = device.send_config_set(commands)
-            if "'^' marker" in output:
-                module.fail_json(msg="Error executing command:\
-                                 {}".format(output))
 
         try:
             if commands_file:
@@ -186,6 +193,10 @@ def main():
         except:
             module.fail_json(msg="Unable to locate: {}".format(commands_file))
 
+    if (error_params(platform,output)):
+        module.fail_json(msg="Error executing command:\
+                         {}".format(output))
+
     results = {}
     results['response'] = output
 
@@ -193,4 +204,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(module)

--- a/library/ntc_write_command
+++ b/library/ntc_write_command
@@ -88,7 +88,7 @@ options:
         default: null
         choices: []
         aliases: []
-    enable_password:
+    secret:
         description:
             - Password used to login to the target device
         required: false
@@ -109,7 +109,7 @@ EXAMPLES = '''
     host: "{{ inventory_hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
-    enable_password: "{{ enable_password }}"
+    secret: "{{ secret }}"
 
 # write config from file
 - ntc_write_command:
@@ -119,7 +119,7 @@ EXAMPLES = '''
     host: "{{ inventory_hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
-    enable_password: "{{ enable_password }}"
+    secret: "{{ secret }}"
 '''
 
 
@@ -136,7 +136,7 @@ def main():
             port=dict(default=22, required=False),
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str'),
-            enable_password=dict(required=False, type='str'),
+            secret=dict(required=False, type='str'),
         ),
         required_together=(
             ['host', 'password', 'username'],
@@ -151,7 +151,7 @@ def main():
     commands_file = module.params['commands_file']
     username = module.params['username']
     password = module.params['password']
-    enable_password = module.params['enable_password']
+    secret = module.params['secret']
     port = int(module.params['port'])
 
     if module.params['host']:
@@ -166,8 +166,8 @@ def main():
                                 ip=socket.gethostbyname(host),
                                 port=port,
                                 username=username,
-                                password=password
-                                secret=enable_password)
+                                password=password,
+                                secret=secret)
 
         if secret:
             device.enable()
@@ -184,7 +184,7 @@ def main():
             module.fail_json(msg="Unable to locate: {}".format(commands_file))
 
     results = {}
-    results['response'] = structured_data
+    results['response'] = output 
 
     module.exit_json(**results)
 

--- a/test-write.yml
+++ b/test-write.yml
@@ -1,0 +1,17 @@
+---
+- name: test ntc_write_command
+  hosts: cisco_ios 
+  connection: local
+  gather_facts: False
+
+  tasks:
+  - name: execute ntc_write_command module
+    ntc_write_command:
+      connection: ssh
+      platform: "cisco_ios"
+      commands:
+        - snmp-server location HOME
+      host: "{{ inventory_hostname }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      secret: "{{ secret }}"


### PR DESCRIPTION
This ansible module allows you to write commands to devices that don't have API access. 

There are two methods of sending commands. The first is simply listing a the commands, as a list, in the commands section. The other is reading a commands_file. The idea behind the commands file is that you can have a play generate remediation commands, based on the output from ntc_show_command, then execute those commands on said device.

Here are a couple examples:

```
# write vlan data
- ntc_write_command:
    connection: ssh
    platform: cisco_nxos
    commands:
      - vlan 10
      - name vlan_10
      - end
    host: "{{ inventory_hostname }}"
    username: "{{ username }}"
    password: "{{ password }}"
    secret: "{{ secret }}"
```
```
# write config from file
- ntc_write_command:
    connection: ssh
    platform: cisco_nxos
    commands_file: "dynamically_created_config.txt"
    host: "{{ inventory_hostname }}"
    username: "{{ username }}"
    password: "{{ password }}"
    secret: "{{ secret }}"
```