### PR TITLE
Added arista_eos_show_clock

### DIFF
--- a/ntc_templates/arista_eos_show_clock.template
+++ b/ntc_templates/arista_eos_show_clock.template
@@ -7,4 +7,4 @@ Value YEAR (\d+)
 
 Start
   ^${DAYWEEK}\s+${MONTH}\s+${DAY}\s+${TIME}\s+${YEAR}
-  ^.imezone(:|\sis)\s+${TIMEZONE} -> Record
+  ^[t|T]imezone(:|\sis)\s+${TIMEZONE} -> Record

--- a/ntc_templates/arista_eos_show_clock.template
+++ b/ntc_templates/arista_eos_show_clock.template
@@ -1,0 +1,10 @@
+Value TIME (\d+:\d+:\d+)
+Value TIMEZONE (\S+)
+Value DAYWEEK (\w+)
+Value MONTH (\w+)
+Value DAY (\d+)
+Value YEAR (\d+)
+
+Start
+  ^${DAYWEEK}\s+${MONTH}\s+${DAY}\s+${TIME}\s+${YEAR}
+  ^.imezone(:|\sis)\s+${TIMEZONE} -> Record

--- a/ntc_templates/index
+++ b/ntc_templates/index
@@ -39,3 +39,4 @@ cisco_ios_show_snmp_community.template, .*, cisco_ios, sh[[ow]] sn[[mp]] com[[mu
 cisco_nxos_show_inventory.template, .*, cisco_nxos, sh[[ow]] inv[[entory]]
 cisco_nxos_show_access-lists.template, .*, cisco_nxos, sh[[ow]] acc[[ess-lists]]
 cisco_ios_show_access-list.template, .*, cisco_ios, sh[[ow]] acc[[ess-list]]
+arista_eos_show_clock.template, .*, arista_eos, sh[[ow]] cl[[ock]]

--- a/tests/arista_eos/show_clock/arista_eos_show_clock.parsed
+++ b/tests/arista_eos/show_clock/arista_eos_show_clock.parsed
@@ -1,0 +1,8 @@
+---
+parsed_sample:
+- time: "18:42:49"
+  timezone: "US/Central"
+  dayweek: "Mon"
+  month: "Jan"
+  day: "14"
+  year: "2013"

--- a/tests/arista_eos/show_clock/arista_eos_show_clock.raw
+++ b/tests/arista_eos/show_clock/arista_eos_show_clock.raw
@@ -1,0 +1,3 @@
+Mon Jan 14 18:42:49 2013
+timezone is US/Central
+


### PR DESCRIPTION
In my vEOS test environment the output is this:

"Tue Nov  3 14:14:18 2015
Timezone: Indian/Comoro
Clock source: local"

While on the EOS command guide a sample output is this:

"Mon Jan 14 18:42:49 2013
timezone is US/Central"

That's why I dediced to write the timezone regex that way (this may seem strange without this note).
