### PR TITLE
Add support for use_keys and key_file netmiko arguments

### DIFF
--- a/library/ntc_config_command
+++ b/library/ntc_config_command
@@ -89,7 +89,18 @@ options:
         default: null
         choices: []
         aliases: []
+    use_keys:
+        description:
+            - Boolean true/false if ssh key login should be attempted
+        required: false
+        default: false
+    key_file:
+        description:
+            - Path to private ssh key used for login
+        required: false
+        default: null
 '''
+
 EXAMPLES = '''
 
 # write vlan data
@@ -145,6 +156,8 @@ def main():
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str'),
             secret=dict(required=False, type='str'),
+            use_keys=dict(required=False, default=False),
+            key_file=dict(required=False, default=None, type='str'),
         ),
         required_together=(
             ['host', 'password', 'username'],
@@ -160,6 +173,8 @@ def main():
     username = module.params['username']
     password = module.params['password']
     secret = module.params['secret']
+    use_keys = module.params['use_keys']
+    key_file = module.params['key_file']
     port = int(module.params['port'])
 
     if module.params['host']:
@@ -175,7 +190,10 @@ def main():
                                 port=port,
                                 username=username,
                                 password=password,
-                                secret=secret)
+                                secret=secret,
+                                use_keys=use_keys,
+                                key_file=key_file
+                                )   
 
         if secret:
             device.enable()

--- a/library/ntc_show_command
+++ b/library/ntc_show_command
@@ -119,7 +119,20 @@ options:
         default: null
         choices: []
         aliases: []
-
+    use_keys:
+        description:
+            - Boolean true/false if ssh key login should be attempted
+        required: false
+        default: false
+        choices: []
+        aliases: []
+    key_file:
+        description:
+            - Path to private ssh key used for login
+        required: false
+        default: null
+        choices: []
+        aliases: []
 '''
 EXAMPLES = '''
 
@@ -191,6 +204,8 @@ def main():
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str'),
             secret=dict(required=False, type='str'),
+            use_keys=dict(required=False, default=False),
+            key_file=dict(required=False, default=None, type='str'),
         ),
         required_together=(
             ['host', 'password', 'username'],
@@ -210,6 +225,8 @@ def main():
     username = module.params['username']
     password = module.params['password']
     secret = module.params['secret']
+    use_keys = module.params['use_keys']
+    key_file = module.params['key_file']
     port = int(module.params['port'])
     delay = int(module.params['delay'])
 
@@ -233,15 +250,18 @@ def main():
 
     if connection == 'ssh':
 
+        import getpass
+        print(getpass.getuser())
         device = ConnectHandler(
                     device_type=device_type,
                     ip=socket.gethostbyname(host),
                     port=port,
                     username=username,
                     password=password,
-                    secret=secret
-                    )
-
+                    secret=secret,
+                    use_keys=use_keys,
+                    key_file=key_file
+                    )   
         if secret:
             device.enable()
 

--- a/ntc_templates/hp_procurve_show_arp.template
+++ b/ntc_templates/hp_procurve_show_arp.template
@@ -1,0 +1,10 @@
+Value IP ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+Value MAC ([0-9a-fA-F]{6}-[0-9a-fA-F]{6})
+Value TYPE (\S+)
+Value PORT (\d+)
+
+Start
+  ^.*IP ARP table -> ARP
+
+ARP
+  ^\s+${IP}\s+${MAC}\s+${TYPE}\s+${PORT} -> Record

--- a/ntc_templates/hp_procurve_show_vlans.template
+++ b/ntc_templates/hp_procurve_show_vlans.template
@@ -1,0 +1,11 @@
+Value VLAN_ID (\d+)
+Value NAME (\S+)
+Value STATUS (\S+)
+Value VOICE (Yes|No)
+Value JUMBO (Yes|No)
+
+Start
+  ^.*VLAN ID -> VLAN
+
+VLAN
+  ^\s+${VLAN_ID}\s+${NAME}\s+${STATUS}\s+${VOICE}\s+${JUMBO} -> Record

--- a/ntc_templates/index
+++ b/ntc_templates/index
@@ -56,3 +56,4 @@ cisco_ios_show_vlan.template, .*, cisco_ios, sh[[ow]] vlan
 dell_force10_show_version.template, .*, dell_force10, sh[[ow]] ver[[sion]]
 dell_force10_show_vlan.template, .*, dell_force10, sh[[ow]] vl[[an]]
 hp_procurve_show_vlans.template, .*, hp_procurve, sh[[ow]] vl[[ans]]
+hp_procurve_show_arp.template, .*, hp_procurve, sh[[ow]] ar[[p]]

--- a/ntc_templates/index
+++ b/ntc_templates/index
@@ -55,3 +55,4 @@ cisco_ios_show_version.template, .*, cisco_ios, sh[[ow]] ver[[sion]]
 cisco_ios_show_vlan.template, .*, cisco_ios, sh[[ow]] vlan
 dell_force10_show_version.template, .*, dell_force10, sh[[ow]] ver[[sion]]
 dell_force10_show_vlan.template, .*, dell_force10, sh[[ow]] vl[[an]]
+hp_procurve_show_vlans.template, .*, hp_procurve, sh[[ow]] vl[[ans]]

--- a/test-template.yml
+++ b/test-template.yml
@@ -7,7 +7,7 @@
   vars_prompt:
     - name: template_name
       prompt: "Enter the name of the template to verify:"
-      default: "hp_procurve_show_vlans"
+      default: "hp_procurve_show_arp"
       private: no
 
     - name: platform

--- a/test-template.yml
+++ b/test-template.yml
@@ -7,12 +7,12 @@
   vars_prompt:
     - name: template_name
       prompt: "Enter the name of the template to verify:"
-      default: "cisco_nxos_show_ip_route"
+      default: "hp_procurve_show_vlans"
       private: no
 
     - name: platform
       prompt: "Enter the platform"
-      default: "cisco_nxos"
+      default: "hp_procurve"
       private: no
 
   tasks:

--- a/tests/hp_procurve/show_arp/hp_procurve_show_arp.parsed
+++ b/tests/hp_procurve/show_arp/hp_procurve_show_arp.parsed
@@ -1,0 +1,19 @@
+---
+
+parsed_sample:
+
+- ip:  "10.11.12.11"
+  mac: "0015b2-a45078"
+  type: "dynamic"
+  port: "2"
+
+- ip:  "10.11.12.12"
+  mac: "0c15b2-a45d78"
+  type: "dynamic"
+  port: "3"
+
+- ip:  "10.11.12.13"
+  mac: "001eb2-a45f78"
+  type: "dynamic"
+  port: "4"
+

--- a/tests/hp_procurve/show_arp/hp_procurve_show_arp.raw
+++ b/tests/hp_procurve/show_arp/hp_procurve_show_arp.raw
@@ -1,0 +1,11 @@
+
+ IP ARP table
+
+  IP Address      MAC Address       Type    Port
+  --------------- ----------------- ------- ----
+  10.11.12.11     0015b2-a45078     dynamic 2   
+  10.11.12.12     0c15b2-a45d78     dynamic 3   
+  10.11.12.13     001eb2-a45f78     dynamic 4   
+ 
+
+

--- a/tests/hp_procurve/show_vlans/hp_procurve_show_vlans.parsed
+++ b/tests/hp_procurve/show_vlans/hp_procurve_show_vlans.parsed
@@ -1,0 +1,31 @@
+---
+
+parsed_sample:
+
+- name: "DEFAULT_VLAN"
+  vlan_id: "1"
+  status: "Port-based"
+  voice: "No"
+  jumbo: "No"
+
+- name: "sixty-six"
+  vlan_id: "66"
+  status: "Port-based"
+  voice: "No"
+  jumbo: "No"
+
+- name: "DEVOPS"
+  vlan_id: "100"
+  status: "Port-based"
+  voice: "No"
+  jumbo: "No"
+  status: "Port-based"
+  voice: "No"
+  jumbo: "No"
+
+- name: "MANAGEMENT"
+  vlan_id: "996"
+  status: "Port-based"
+  voice: "No"
+  jumbo: "No"
+

--- a/tests/hp_procurve/show_vlans/hp_procurve_show_vlans.raw
+++ b/tests/hp_procurve/show_vlans/hp_procurve_show_vlans.raw
@@ -1,0 +1,12 @@
+ Status and Counters - VLAN Information
+
+  Maximum VLANs to support : 8                    
+  Primary VLAN : DEFAULT_VLAN
+  Management VLAN :             
+
+  802.1Q VLAN ID Name         Status       Voice Jumbo
+  -------------- ------------ ------------ ----- -----
+  1              DEFAULT_VLAN Port-based   No    No   
+  66             sixty-six    Port-based   No    No   
+  100            DEVOPS       Port-based   No    No   
+  996            MANAGEMENT   Port-based   No    No   


### PR DESCRIPTION
Tested with force10 s4810 switch.  Full disclosure: there's an issue with netmiko/paramiko that requires a valid password for the key exchange to work (at least for the s4810 in my testing).  In any case, it's nice to have the key option available.