### PR TITLE
Add support for use_keys and key_file netmiko arguments.

### DIFF
--- a/library/ntc_config_command
+++ b/library/ntc_config_command
@@ -89,7 +89,18 @@ options:
         default: null
         choices: []
         aliases: []
+    use_keys:
+        description:
+            - Boolean true/false if ssh key login should be attempted
+        required: false
+        default: false
+    key_file:
+        description:
+            - Path to private ssh key used for login
+        required: false
+        default: null
 '''
+
 EXAMPLES = '''
 
 # write vlan data
@@ -145,6 +156,8 @@ def main():
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str'),
             secret=dict(required=False, type='str'),
+            use_keys=dict(required=False, default=False),
+            key_file=dict(required=False, default=None, type='str'),
         ),
         required_together=(
             ['host', 'password', 'username'],
@@ -160,6 +173,8 @@ def main():
     username = module.params['username']
     password = module.params['password']
     secret = module.params['secret']
+    use_keys = module.params['use_keys']
+    key_file = module.params['key_file']
     port = int(module.params['port'])
 
     if module.params['host']:
@@ -175,7 +190,10 @@ def main():
                                 port=port,
                                 username=username,
                                 password=password,
-                                secret=secret)
+                                secret=secret,
+                                use_keys=use_keys,
+                                key_file=key_file
+                                )   
 
         if secret:
             device.enable()

--- a/library/ntc_show_command
+++ b/library/ntc_show_command
@@ -250,8 +250,6 @@ def main():
 
     if connection == 'ssh':
 
-        import getpass
-        print(getpass.getuser())
         device = ConnectHandler(
                     device_type=device_type,
                     ip=socket.gethostbyname(host),

--- a/library/ntc_show_command
+++ b/library/ntc_show_command
@@ -119,7 +119,20 @@ options:
         default: null
         choices: []
         aliases: []
-
+    use_keys:
+        description:
+            - Boolean true/false if ssh key login should be attempted
+        required: false
+        default: false
+        choices: []
+        aliases: []
+    key_file:
+        description:
+            - Path to private ssh key used for login
+        required: false
+        default: null
+        choices: []
+        aliases: []
 '''
 EXAMPLES = '''
 
@@ -191,6 +204,8 @@ def main():
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str'),
             secret=dict(required=False, type='str'),
+            use_keys=dict(required=False, default=False),
+            key_file=dict(required=False, default=None, type='str'),
         ),
         required_together=(
             ['host', 'password', 'username'],
@@ -210,6 +225,8 @@ def main():
     username = module.params['username']
     password = module.params['password']
     secret = module.params['secret']
+    use_keys = module.params['use_keys']
+    key_file = module.params['key_file']
     port = int(module.params['port'])
     delay = int(module.params['delay'])
 
@@ -233,15 +250,18 @@ def main():
 
     if connection == 'ssh':
 
+        import getpass
+        print(getpass.getuser())
         device = ConnectHandler(
                     device_type=device_type,
                     ip=socket.gethostbyname(host),
                     port=port,
                     username=username,
                     password=password,
-                    secret=secret
-                    )
-
+                    secret=secret,
+                    use_keys=use_keys,
+                    key_file=key_file
+                    )   
         if secret:
             device.enable()
 


### PR DESCRIPTION
Tested with force10 s4810 switch. Full disclosure: there's an issue with netmiko/paramiko that requires a valid password for the key exchange to work (at least for the s4810 in my testing). In any case, it's nice to have the key option available.