### PR TITLE
updatd default templates dir

### DIFF
--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -216,6 +216,12 @@ vars:
 import os.path
 import socket
 
+HAS_NTC_TEMPLATES = True
+try:
+    from ntc_templates.parse import _get_template_dir as ntc_get_template_dir
+except:
+    HAS_NTC_TEMPLATES = False
+
 HAS_NETMIKO = True
 try:
     from netmiko import ConnectHandler
@@ -239,6 +245,10 @@ try:
 except:
     HAS_TRIGGER = False
 
+if HAS_NTC_TEMPLATES:
+    NTC_TEMPLATES_DIR = ntc_get_template_dir()
+else:
+    NTC_TEMPLATES_DIR = 'ntc_templates/templates'
 
 def clitable_to_dict(cli_table):
     """Converts TextFSM cli_table object to list of dictionaries
@@ -302,7 +312,7 @@ def main():
             file=dict(required=False),
             local_file=dict(required=False),
             index_file=dict(default='index'),
-            template_dir=dict(default='ntc-templates/templates'),
+            template_dir=dict(default=NTC_TEMPLATES_DIR),
             use_templates=dict(required=False, default=True, type='bool'),
             trigger_device_list=dict(type='list', required=False),
             command=dict(required=True),


### PR DESCRIPTION
@ogenstad made the ntc-templates project it's own installable a LONG time ago...after frequent issues with the default path in ntc_show_command, thought it finally made sense to do this.  Basically, clone ntc-templates and run its setup.py - otherwise, same boat as today.

Note: if you use the default path, it does require a git pull and re-install b/c it places the templates in site-packages...if not, doing `python setup.py develop` would work too.  

@GGabriele @itdependsnetworks 