### PR TITLE
Support for ASA & F5 devices in install_os, reboot, file_copy operations

### DIFF
--- a/library/ntc_file_copy.py
+++ b/library/ntc_file_copy.py
@@ -37,7 +37,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_rest']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
     local_file:
         description:
             - Path to local file. Local directory must exist.
@@ -185,7 +185,7 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
-PLATFORM_f5 = 'f5_tmos_rest'
+PLATFORM_f5 = 'f5_tmos_icontrol'
 
 def main():
     module = AnsibleModule(

--- a/library/ntc_file_copy.py
+++ b/library/ntc_file_copy.py
@@ -185,12 +185,14 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
-PLATFORM_f5 = 'f5_tmos_icontrol'
+PLATFORM_F5 = 'f5_tmos_icontrol'
+
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS, PLATFORM_f5],
+            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
+                                   PLATFORM_JUNOS, PLATFORM_F5],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),
@@ -214,7 +216,7 @@ def main():
                             ['ntc_conf_file', 'secret'],
                             ['ntc_conf_file', 'transport'],
                             ['ntc_conf_file', 'port'],
-                           ],
+                            ],
         required_one_of=[['host', 'ntc_host', 'provider']],
         supports_check_mode=True
     )
@@ -230,7 +232,6 @@ def main():
     for param, pvalue in provider.items():
         if module.params.get(param) != False:
             module.params[param] = module.params.get(param) or pvalue
-
 
     if not HAS_PYNTC:
         module.fail_json(msg='pyntc Python library not found.')
@@ -271,8 +272,8 @@ def main():
     remote_file = module.params['remote_file']
     file_system = module.params['file_system']
 
-
-    argument_check = { 'host': host, 'username': username, 'platform': platform, 'password': password, 'local_file': local_file }
+    argument_check = {'host': host, 'username': username, 'platform': platform,
+                      'password': password, 'local_file': local_file}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
@@ -287,7 +288,8 @@ def main():
         module.fail_json(msg="Local file {} not found".format(local_file))
 
     if file_system:
-        remote_exists = device.file_copy_remote_exists(local_file, remote_file, file_system=file_system)
+        remote_exists = device.file_copy_remote_exists(local_file, remote_file,
+                                                       file_system=file_system)
     else:
         remote_exists = device.file_copy_remote_exists(local_file, remote_file)
 
@@ -298,7 +300,8 @@ def main():
     if not module.check_mode and not file_exists:
         try:
             if file_system:
-                device.file_copy(local_file, remote_file, file_system=file_system)
+                device.file_copy(local_file, remote_file,
+                                 file_system=file_system)
             else:
                 device.file_copy(local_file, remote_file)
 
@@ -319,5 +322,7 @@ def main():
                      local_file=local_file, remote_file=remote_file,
                      file_system=file_system, atomic=atomic)
 
+
 from ansible.module_utils.basic import *
+
 main()

--- a/library/ntc_file_copy.py
+++ b/library/ntc_file_copy.py
@@ -37,7 +37,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_rest']
     local_file:
         description:
             - Path to local file. Local directory must exist.
@@ -185,12 +185,12 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
-
+PLATFORM_f5 = 'f5_tmos_rest'
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS],
+            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS, PLATFORM_f5],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),

--- a/library/ntc_file_copy.py
+++ b/library/ntc_file_copy.py
@@ -37,7 +37,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'cisco_asa_ssh', 'f5_tmos_icontrol']
     local_file:
         description:
             - Path to local file. Local directory must exist.
@@ -186,13 +186,14 @@ PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
 PLATFORM_F5 = 'f5_tmos_icontrol'
+PLATFORM_ASA = 'cisco_asa_ssh'
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
             platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
-                                   PLATFORM_JUNOS, PLATFORM_F5],
+                                   PLATFORM_JUNOS, PLATFORM_F5, PLATFORM_ASA],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),

--- a/library/ntc_get_facts.py
+++ b/library/ntc_get_facts.py
@@ -35,7 +35,7 @@ options:
             - Switch platform
         required: false
         default: null
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
     host:
         description:
             - Hostame or IP address of switch.
@@ -208,12 +208,14 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
+PLATFORM_f5 = 'f5_tmos_icontrol'
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS],
+            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
+                                   PLATFORM_JUNOS, PLATFORM_f5],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),
@@ -232,7 +234,7 @@ def main():
                             ['ntc_conf_file', 'secret'],
                             ['ntc_conf_file', 'transport'],
                             ['ntc_conf_file', 'port'],
-                           ],
+                            ],
         required_one_of=[['host', 'ntc_host', 'provider']],
         supports_check_mode=False
     )
@@ -264,7 +266,8 @@ def main():
     port = module.params['port']
     secret = module.params['secret']
 
-    argument_check = { 'host': host, 'username': username, 'platform': platform, 'password': password }
+    argument_check = {'host': host, 'username': username, 'platform': platform,
+                      'password': password}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
@@ -289,5 +292,7 @@ def main():
 
     module.exit_json(ansible_facts=facts)
 
+
 from ansible.module_utils.basic import *
+
 main()

--- a/library/ntc_get_facts.py
+++ b/library/ntc_get_facts.py
@@ -208,14 +208,14 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
-PLATFORM_f5 = 'f5_tmos_icontrol'
+PLATFORM_F5 = 'f5_tmos_icontrol'
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
             platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
-                                   PLATFORM_JUNOS, PLATFORM_f5],
+                                   PLATFORM_JUNOS, PLATFORM_F5],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),

--- a/library/ntc_install_os.py
+++ b/library/ntc_install_os.py
@@ -166,7 +166,7 @@ PLATFORM_ASA = 'cisco_asa_ssh'
 
 def already_set(boot_options, system_image_file, kickstart_image_file,
                 **kwargs):
-    volume = kwargs.get('volume', "")
+    volume = kwargs.get('volume')
     device = kwargs.get('device')
     if device and volume:
         return device.image_installed(image_name=system_image_file,

--- a/library/ntc_install_os.py
+++ b/library/ntc_install_os.py
@@ -39,7 +39,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_rest']
     system_image_file:
         description:
             - Name of the system (or combined) image file on flash.
@@ -49,6 +49,10 @@ options:
             - Name of the kickstart image file on flash.
         required: false
         default: null
+    volume:
+        description:
+            - Name of F5 Volume (installation target)
+        required: false
     host:
         description:
             - Hostame or IP address of switch.

--- a/library/ntc_install_os.py
+++ b/library/ntc_install_os.py
@@ -39,7 +39,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_rest']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
     system_image_file:
         description:
             - Name of the system (or combined) image file on flash.
@@ -159,7 +159,7 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
-PLATFORM_F5 = 'f5_tmos_rest'
+PLATFORM_F5 = 'f5_tmos_icontrol'
 
 
 def already_set(boot_options, system_image_file, kickstart_image_file,

--- a/library/ntc_install_os.py
+++ b/library/ntc_install_os.py
@@ -26,6 +26,7 @@ notes:
     - Do not include full file paths, just the name of the file(s) stored on the top level flash directory.
     - You must know if your platform supports taking a kickstart image as a parameter. If supplied but not supported, errors may occur.
     - It may be useful to use this module in conjuction with ntc_file_copy and ntc_reboot.
+    - With F5, volume parameter is required.
     - With NXOS devices, this module attempts to install the software immediately, wich may trigger a reboot.
     - With NXOS devices, install process may take up to 10 minutes, especially if the device reboots.
     - Tested on Nexus 3000, 5000, 9000.
@@ -39,7 +40,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'cisco_asa_ssh', 'f5_tmos_icontrol']
     system_image_file:
         description:
             - Name of the system (or combined) image file on flash.
@@ -160,6 +161,7 @@ PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
 PLATFORM_F5 = 'f5_tmos_icontrol'
+PLATFORM_ASA = 'cisco_asa_ssh'
 
 
 def already_set(boot_options, system_image_file, kickstart_image_file,
@@ -178,7 +180,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
-                                   PLATFORM_JUNOS, PLATFORM_F5],
+                                   PLATFORM_JUNOS, PLATFORM_F5, PLATFORM_ASA],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),

--- a/library/ntc_install_os.py
+++ b/library/ntc_install_os.py
@@ -292,7 +292,7 @@ def main():
                 except:
                     time.sleep(10)
                     elapsed_time += 10
-        elif device.device_type == 'f5_tmos_rest':
+        elif device.device_type == PLATFORM_F5:
             device.set_boot_options(image_name=system_image_file, volume=volume)
             install_state = device.get_boot_options()
         else:

--- a/library/ntc_install_os.py
+++ b/library/ntc_install_os.py
@@ -49,9 +49,10 @@ options:
             - Name of the kickstart image file on flash.
         required: false
         default: null
-    volume:
+    vendor_args:
         description:
-            - Name of F5 Volume (installation target)
+            - Dictionary with vendor specific information.
+              Currently supported options: "volume" as a target boot destination for F5.
         required: false
     host:
         description:

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -50,9 +50,10 @@ options:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         required: false
         default: false
-    volume:
+    vendor_args:
         description:
-            - Name of F5 Volume (installation target)
+            - Dictionary with vendor specific information.
+              Currently supported options: "volume" as a target boot destination for F5.
         required: false
     host:
         description:

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -226,7 +226,7 @@ def main():
             confirm=dict(required=False, default=False, type='bool'),
             timer=dict(requred=False, type='int'),
             timeout=dict(required=False, type='int', default=240),
-            volume=dict(required=False, type='str')
+            vendor_args=dict(required=False, type='dict', default={}),
         ),
         mutually_exclusive=[['host', 'ntc_host'],
                             ['ntc_host', 'secret'],
@@ -259,7 +259,6 @@ def main():
     host = module.params['host']
     username = module.params['username']
     password = module.params['password']
-    volume = module.params['volume']
 
     ntc_host = module.params['ntc_host']
     ntc_conf_file = module.params['ntc_conf_file']
@@ -290,6 +289,7 @@ def main():
     confirm = module.params['confirm']
     timer = module.params['timer']
     timeout = module.params['timeout']
+    vendor_args = module.params['vendor_args']
 
     if not confirm:
         module.fail_json(msg='confirm must be set to true for this module to work.')
@@ -306,13 +306,12 @@ def main():
             module.fail_json(msg=str(key) + " is required")
     device.open()
 
-    changed = False
-    rebooted = False
+    volume = vendor_args.get('volume', '')
 
-    if timer is not None:
-        device.reboot(confirm=True, timer=timer)
-    elif volume is not None and device.device_type == 'f5_tmos_rest':
+    if volume:
         device.reboot(confirm=True, volume=volume)
+    elif timer is not None:
+        device.reboot(confirm=True, timer=timer)
     else:
         device.reboot(confirm=True)
 

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -33,7 +33,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_rest']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
     timer:
         description:
             - Time in minutes after which the device will be rebooted.
@@ -180,7 +180,7 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
-PLATFORM_F5 = 'f5_tmos_rest'
+PLATFORM_F5 = 'f5_tmos_icontrol'
 
 
 def check_device(module, username, password, host, timeout, kwargs):

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -33,7 +33,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_icontrol']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'cisco_asa_ssh', 'f5_tmos_icontrol']
     timer:
         description:
             - Time in minutes after which the device will be rebooted.
@@ -181,7 +181,7 @@ PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
 PLATFORM_F5 = 'f5_tmos_icontrol'
-
+PLATFORM_ASA = 'cisco_asa_ssh'
 
 def check_device(module, username, password, host, timeout, kwargs):
     success = False
@@ -214,7 +214,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
-                                   PLATFORM_JUNOS, PLATFORM_F5],
+                                   PLATFORM_JUNOS, PLATFORM_F5, PLATFORM_ASA],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -33,7 +33,7 @@ options:
         description:
             - Switch platform
         required: false
-        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh']
+        choices: ['cisco_nxos_nxapi', 'arista_eos_eapi', 'cisco_ios_ssh', 'f5_tmos_rest']
     timer:
         description:
             - Time in minutes after which the device will be rebooted.
@@ -50,6 +50,10 @@ options:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         required: false
         default: false
+    volume:
+        description:
+            - Name of F5 Volume (installation target)
+        required: false
     host:
         description:
             - Hostame or IP address of switch.
@@ -176,6 +180,7 @@ PLATFORM_NXAPI = 'cisco_nxos_nxapi'
 PLATFORM_IOS = 'cisco_ios_ssh'
 PLATFORM_EAPI = 'arista_eos_eapi'
 PLATFORM_JUNOS = 'juniper_junos_netconf'
+PLATFORM_F5 = 'f5_tmos_rest'
 
 
 def check_device(module, username, password, host, timeout, kwargs):
@@ -207,7 +212,7 @@ def check_device(module, username, password, host, timeout, kwargs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS],
+            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS, PLATFORM_F5],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),
@@ -220,7 +225,8 @@ def main():
             ntc_conf_file=dict(required=False),
             confirm=dict(required=False, default=False, type='bool'),
             timer=dict(requred=False, type='int'),
-            timeout=dict(required=False, type='int', default=240)
+            timeout=dict(required=False, type='int', default=240),
+            volume=dict(required=False, type='str')
         ),
         mutually_exclusive=[['host', 'ntc_host'],
                             ['ntc_host', 'secret'],
@@ -253,6 +259,7 @@ def main():
     host = module.params['host']
     username = module.params['username']
     password = module.params['password']
+    volume = module.params['volume']
 
     ntc_host = module.params['ntc_host']
     ntc_conf_file = module.params['ntc_conf_file']

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -50,10 +50,9 @@ options:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         required: false
         default: false
-    vendor_args:
+    volume:
         description:
-            - Dictionary with vendor specific information.
-              Currently supported options: "volume" as a target boot destination for F5.
+            - Volume name - required argument for F5 platform.
         required: false
     host:
         description:
@@ -196,7 +195,8 @@ def check_device(module, username, password, host, timeout, kwargs):
                                             module.params['ntc_conf_file'])
             else:
                 device_type = module.params['platform']
-                device = ntc_device(device_type, host, username, password, **kwargs)
+                device = ntc_device(device_type, host, username, password,
+                                    **kwargs)
             success = True
             atomic = True
             try:
@@ -213,7 +213,8 @@ def check_device(module, username, password, host, timeout, kwargs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI, PLATFORM_JUNOS, PLATFORM_F5],
+            platform=dict(choices=[PLATFORM_NXAPI, PLATFORM_IOS, PLATFORM_EAPI,
+                                   PLATFORM_JUNOS, PLATFORM_F5],
                           required=False),
             host=dict(required=False),
             username=dict(required=False, type='str'),
@@ -227,7 +228,7 @@ def main():
             confirm=dict(required=False, default=False, type='bool'),
             timer=dict(requred=False, type='int'),
             timeout=dict(required=False, type='int', default=240),
-            vendor_args=dict(required=False, type='dict', default={}),
+            volume=dict(required=False, type='str'),
         ),
         mutually_exclusive=[['host', 'ntc_host'],
                             ['ntc_host', 'secret'],
@@ -236,8 +237,9 @@ def main():
                             ['ntc_conf_file', 'secret'],
                             ['ntc_conf_file', 'transport'],
                             ['ntc_conf_file', 'port'],
-                           ],
+                            ],
         required_one_of=[['host', 'ntc_host', 'provider']],
+        required_if=[["platform", PLATFORM_F5, ["volume"]]],
         supports_check_mode=False
     )
 
@@ -268,7 +270,8 @@ def main():
     port = module.params['port']
     secret = module.params['secret']
 
-    argument_check = { 'host': host, 'username': username, 'platform': platform, 'password': password }
+    argument_check = {'host': host, 'username': username, 'platform': platform,
+                      'password': password}
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
@@ -290,24 +293,26 @@ def main():
     confirm = module.params['confirm']
     timer = module.params['timer']
     timeout = module.params['timeout']
-    vendor_args = module.params['vendor_args']
+    volume = module.params['volume']
 
     if not confirm:
-        module.fail_json(msg='confirm must be set to true for this module to work.')
+        module.fail_json(
+            msg='confirm must be set to true for this module to work.')
 
     supported_timer_platforms = [PLATFORM_IOS, PLATFORM_JUNOS]
 
-    if timer is not None \
-            and device.device_type not in supported_timer_platforms:
-        module.fail_json(msg='Timer parameter not supported on platform %s.' % platform)
+    if timer is not None and device.device_type not in supported_timer_platforms:
+        module.fail_json(
+            msg='Timer parameter not supported on platform %s.' % platform)
 
-    argument_check = { 'host': host, 'username': username, 'platform': platform, 'password': password }
+    argument_check = {'host': host, 'username': username, 'platform': platform,
+                      'password': password}
+
     for key, val in argument_check.items():
         if val is None:
             module.fail_json(msg=str(key) + " is required")
-    device.open()
 
-    volume = vendor_args.get('volume', '')
+    device.open()
 
     if volume:
         device.reboot(confirm=True, volume=volume)
@@ -317,12 +322,16 @@ def main():
         device.reboot(confirm=True)
 
     time.sleep(10)
-    reachable, atomic = check_device(module, username, password, host, timeout, kwargs)
+    reachable, atomic = check_device(module, username, password, host, timeout,
+                                     kwargs)
 
     changed = True
     rebooted = True
 
-    module.exit_json(changed=changed, rebooted=rebooted, reachable=reachable, atomic=atomic)
+    module.exit_json(changed=changed, rebooted=rebooted, reachable=reachable,
+                     atomic=atomic)
+
 
 from ansible.module_utils.basic import *
+
 main()

--- a/library/ntc_reboot.py
+++ b/library/ntc_reboot.py
@@ -311,6 +311,8 @@ def main():
 
     if timer is not None:
         device.reboot(confirm=True, timer=timer)
+    elif volume is not None and device.device_type == 'f5_tmos_rest':
+        device.reboot(confirm=True, volume=volume)
     else:
         device.reboot(confirm=True)
 


### PR DESCRIPTION
This PR adds support for Cisco ASA & F5 devices in following operations:

- install_os,
- file_copy,
- reboot