### PR TITLE
Delete if sentence for restricting telnet connection to cisco_ios.

### DIFF
--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -201,10 +201,6 @@ def main():
     if module.params['host']:
         host = socket.gethostbyname(module.params['host'])
 
-    if connection == 'telnet' and platform != 'cisco_ios':
-        module.fail_json(msg='only cisco_ios supports '
-                             'telnet connection')
-
     if platform == 'cisco_ios' and connection == 'telnet':
         device_type = 'cisco_ios_telnet'
 

--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -392,10 +392,6 @@ def main():
         module.fail_json(msg='specify host when connection='
                              'ssh/netmiko_ssh/netmiko_telnet')
 
-    if connection in ['netmiko_telnet', 'telnet'] and platform != 'cisco_ios':
-        module.fail_json(msg='only cisco_ios supports '
-                             'telnet/netmiko_telnet connection')
-
     if platform == 'cisco_ios' and connection in ['netmiko_telnet', 'telnet']:
         device_type = 'cisco_ios_telnet'
 


### PR DESCRIPTION
Netmiko now supports various telnet connections such as cisco_ios, juniper_junos, arista_eos, and apresia_aeos. 