### PR TITLE
ntc_show_command: better to fail on parse errors?

### DIFF
--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -296,10 +296,7 @@ def get_structured_data(rawoutput, module):
         cli_table.ParseCmd(rawoutput, attrs)
         structured_data = clitable_to_dict(cli_table)
     except CliTableError as e:
-        # Invalid or Missing template
-        # module.fail_json(msg='parsing error', error=str(e))
-        # rather than fail, fallback to return raw text
-        structured_data = [rawoutput]
+        module.fail_json(msg='parsing error', error=str(e))
 
     return structured_data
 


### PR DESCRIPTION
Currently, there is no way to track parsing errors in `ntc_show_command` module

Whenever there were a mistake or template was missing, you still get
- response, response_list as arrays
- changed, failed set to always False

Better to track parsing errors explicitly in playbooks or suppress through `ignore_errors: True`.