### PR TITLE
Delete obsolete split filter

### DIFF
--- a/filter_plugins/split.py
+++ b/filter_plugins/split.py
@@ -4,7 +4,7 @@ import re
 def split_string(string, separator=' '):
     try:
         return string.split(separator)
-    except Exception, e:
+    except Exception as e:
         raise errors.AnsibleFilterError('split plugin error: %s, string=%s' % str(e),str(string) )
 
 


### PR DESCRIPTION
- Currently it is not python3 compliant (causes load WARNING in ansible)
- A replacement is `str.splt(separator)` which is supported in Jinja2