### PR TITLE
change ansible version check to comply with >=2.10

### DIFF
--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -142,7 +142,7 @@ except ImportError:
 
 
 from ansible import __version__ as ansible_version
-if float(ansible_version[:3]) < 2.4:
+if float(".".join(ansible_version.split(".", 2)[:2])) < 2.4:
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 

--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -233,7 +233,7 @@ import os.path
 import socket
 
 from ansible import __version__ as ansible_version
-if float(ansible_version[:3]) < 2.4:
+if float(".".join(ansible_version.split(".", 2)[:2])) < 2.4:
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 HAS_NTC_TEMPLATES = True


### PR DESCRIPTION
In order to check Ansible version from 2.10 and up, a change was needed in the ansible_version check. Instead of check the first 3 characters for version it will split on periods and join again. So 2.10.1 is seens as version 2.10 and not 2.1