### PR TITLE
Add support a2.10

### DIFF
--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -148,7 +148,7 @@ except ImportError:
     HAS_PACKAGING = False
 from ansible import __version__ as ansible_version
 
-if version.parse(ansible_version) < version.parse("2.4"):
+if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4")) or (not HAS_PACKAGING and float(ansible_version[:3])) < 2.4):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 

--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -141,8 +141,10 @@ except ImportError:
     HAS_NETMIKO=False
 
 
+from packaging import version
 from ansible import __version__ as ansible_version
-if float(".".join(ansible_version.split(".", 2)[:2])) < 2.4:
+
+if version.parse(ansible_version) < version.parse("2.4"):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 

--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -141,7 +141,11 @@ except ImportError:
     HAS_NETMIKO=False
 
 
-from packaging import version
+try:
+    from packaging import version
+    HAS_PACKAGING = True
+except ImportError:
+    HAS_PACKAGING = False
 from ansible import __version__ as ansible_version
 
 if version.parse(ansible_version) < version.parse("2.4"):

--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -141,14 +141,13 @@ except ImportError:
     HAS_NETMIKO=False
 
 
+from ansible import __version__ as ansible_version
 try:
     from packaging import version
-    HAS_PACKAGING = True
+    HAS_PACKAGING=True
 except ImportError:
-    HAS_PACKAGING = False
-from ansible import __version__ as ansible_version
-
-if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4")) or (not HAS_PACKAGING and float(ansible_version[:3])) < 2.4):
+    HAS_PACKAGING=False
+if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4") or (not HAS_PACKAGING and float(ansible_version[:3]) < 2.4)):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 

--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -142,7 +142,7 @@ except ImportError:
 
 
 from ansible import __version__ as ansible_version
-if float(ansible_version[:3]) < 2.4:
+if float(".".join(ansible_version.split(".", 2)[:2])) < 2.4:
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 

--- a/library/ntc_config_command.py
+++ b/library/ntc_config_command.py
@@ -147,7 +147,7 @@ try:
     HAS_PACKAGING=True
 except ImportError:
     HAS_PACKAGING=False
-if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4") or (not HAS_PACKAGING and float(ansible_version[:3]) < 2.4)):
+if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4")) or (not HAS_PACKAGING and float(ansible_version[:3]) < 2.4):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 

--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -232,10 +232,14 @@ vars:
 import os.path
 import socket
 
-from packaging import version
+try:
+    from packaging import version
+    HAS_PACKAGING = True
+except ImportError:
+    HAS_PACKAGING = False
 from ansible import __version__ as ansible_version
 
-if version.parse(ansible_version) < version.parse("2.4"):
+if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4")) or (not HAS_PACKAGING and float(ansible_version[:3])) < 2.4):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 HAS_NTC_TEMPLATES = True

--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -233,7 +233,7 @@ import os.path
 import socket
 
 from ansible import __version__ as ansible_version
-if float(ansible_version[:3]) < 2.4:
+if float(".".join(ansible_version.split(".", 2)[:2])) < 2.4:
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 HAS_NTC_TEMPLATES = True

--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -239,7 +239,7 @@ except ImportError:
     HAS_PACKAGING = False
 from ansible import __version__ as ansible_version
 
-if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4")) or (not HAS_PACKAGING and float(ansible_version[:3])) < 2.4):
+if (HAS_PACKAGING and version.parse(ansible_version) < version.parse("2.4")) or (not HAS_PACKAGING and float(ansible_version[:3]) < 2.4):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 HAS_NTC_TEMPLATES = True

--- a/library/ntc_show_command.py
+++ b/library/ntc_show_command.py
@@ -232,8 +232,10 @@ vars:
 import os.path
 import socket
 
+from packaging import version
 from ansible import __version__ as ansible_version
-if float(".".join(ansible_version.split(".", 2)[:2])) < 2.4:
+
+if version.parse(ansible_version) < version.parse("2.4"):
     raise ImportError("Ansible versions < 2.4 are not supported")
 
 HAS_NTC_TEMPLATES = True


### PR DESCRIPTION
Instead of dealing with the string variable and split for compare. I included the packaging.version module to compare full version numbering of Ansible. Now Ansible version 2.10.1 is seen as higher than 2.4.