### PR TITLE
Update GitHub Actions runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on: # yamllint disable
 
 jobs:
   lint:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
@@ -22,7 +22,7 @@ jobs:
       - name: "Linting"
         run: "invoke lint"
   test:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       fail-fast: true
       matrix:
@@ -37,7 +37,7 @@ jobs:
     needs:
       - "lint"
   integration:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +91,7 @@ jobs:
       - "test"
   publish_github:
     name: "Publish to GitHub"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: "Check out repository code"
@@ -116,7 +116,7 @@ jobs:
       - "integration"
   publish_galaxy:
     name: "Publish to Ansible Galaxy"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: "Check out repository code"


### PR DESCRIPTION
In April 2025, ubuntu-20.04 runners will be gone.

Note: Based on https://github.com/networktocode/schema-enforcer/pull/173, we can use 24.04 instead of 22.04

_I didn't update any Python versions within ci.yml as that may not be a pressing item to change at the moment._